### PR TITLE
fix: convert mv for pt

### DIFF
--- a/features/Raytracing/Shaders/Raytracing/ConvertTexturesCS.hlsl
+++ b/features/Raytracing/Shaders/Raytracing/ConvertTexturesCS.hlsl
@@ -27,7 +27,7 @@ void main(uint2 id : SV_DispatchThreadID)
         return;
 
     const float2 uv = float2(id.xy + 0.5f) * RenderResRcp;
-
+#ifndef PT
     const unorm half3 normalGlossiness = NormalGlossiness.SampleLevel(Sampler, uv, 0).xyz;
     const snorm half3 normalWS = normalize(ViewToWorldVector(GBuffer::DecodeNormal(normalGlossiness.xy), FrameBuffer::CameraViewInverse[0]));
     NormalRoughness[id] = half4(normalWS, 1.0f - normalGlossiness.z);
@@ -37,7 +37,7 @@ void main(uint2 id : SV_DispatchThreadID)
 
     const float4 albedo = Albedo.SampleLevel(Sampler, uv, 0);
     Diffuse[id] = float4(Color::GammaToTrueLinear(albedo.rgb) * (1.0f - metallic), albedo.a);
-
+#endif
     MotionVectorsOut[id] = MotionVectors.SampleLevel(Sampler, uv, 0);
 }
 

--- a/src/Features/Raytracing.cpp
+++ b/src/Features/Raytracing.cpp
@@ -1403,7 +1403,7 @@ void Raytracing::ConvertTextures() const
 	auto context = globals::d3d::context;
 	auto renderer = globals::game::renderer;
 
-	context->CSSetShader(convertTexturesCS.get(), nullptr, 0);
+	context->CSSetShader(settings.PathTracing ? convertTexturesPTCS.get() : convertTexturesCS.get(), nullptr, 0);
 
 	auto* renderSizeCB = renderResCB->CB();
 	context->CSSetConstantBuffers(0, 1, &renderSizeCB);
@@ -2602,8 +2602,7 @@ void Raytracing::DrawRTGI()
 		d3d11Context->ClearRenderTargetView(rendererRuntimeData.renderTargets[ALBEDO].RTV, clearColor);
 	}
 
-	if (!settings.PathTracing)
-		ConvertTextures();
+	ConvertTextures();
 
 	// Wait for D3D11 to finish
 	{
@@ -3837,6 +3836,9 @@ void Raytracing::CompileComputeShaders()
 
 	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\Raytracing\\ConvertTexturesCS.hlsl", { { "DX11", "" } }, "cs_5_0")); rawPtr)
 		convertTexturesCS.attach(rawPtr);
+
+	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\Raytracing\\ConvertTexturesCS.hlsl", { { "DX11", "" }, { "PT", "" } }, "cs_5_0")); rawPtr)
+		convertTexturesPTCS.attach(rawPtr);
 
 	if (auto rawPtr = reinterpret_cast<ID3D11ComputeShader*>(Util::CompileShader(L"Data\\Shaders\\Raytracing\\TrueLinearToGammaCS.hlsl", { { "DX11", "" } }, "cs_5_0")); rawPtr)
 		trueLinearToGammaCS.attach(rawPtr);

--- a/src/Features/Raytracing.h
+++ b/src/Features/Raytracing.h
@@ -725,6 +725,7 @@ struct Raytracing : public OverlayFeature
 	winrt::com_ptr<ID3D11SamplerState> samplerState = nullptr;
 	winrt::com_ptr<ID3D11ComputeShader> copyDepthCS = nullptr;
 	winrt::com_ptr<ID3D11ComputeShader> convertTexturesCS = nullptr;
+	winrt::com_ptr<ID3D11ComputeShader> convertTexturesPTCS = nullptr;
 	winrt::com_ptr<ID3D11ComputeShader> trueLinearToGammaCS = nullptr;
 
 	eastl::unique_ptr<DX12::StructuredBufferUpload<D3D12_RAYTRACING_INSTANCE_DESC>> blasInstanceBuffer = nullptr;


### PR DESCRIPTION
This pull request adds support for path tracing to the texture conversion step in the raytracing pipeline. The main changes include introducing a new compute shader variant for path tracing, updating shader compilation and selection logic, and ensuring the correct shader is used based on the rendering mode.

**Path Tracing Support**

* Added a new compute shader variant, `convertTexturesPTCS`, that is compiled with the `PT` preprocessor definition for path tracing mode. (`src/Features/Raytracing.h`, `src/Features/Raytracing.cpp`) [[1]](diffhunk://#diff-a2b0adfd7d85a7a7384a583c129f56bef6e5a3f1b3d33ac36bd13cb3270240a0R728) [[2]](diffhunk://#diff-537ad86dd1522d625128ed4b9e589dab96660ef24efd55fb80d087d7af260793R3840-R3842)

**Shader Selection Logic**

* Updated `ConvertTextures()` to select either the standard or path tracing compute shader based on the `settings.PathTracing` flag. (`src/Features/Raytracing.cpp`)

**Shader Compilation**

* Modified `CompileComputeShaders()` to compile both standard and path tracing variants of the texture conversion compute shader. (`src/Features/Raytracing.cpp`)

**Shader Dispatch Changes**

* Adjusted the main texture conversion shader (`ConvertTexturesCS.hlsl`) to conditionally execute code based on the `PT` preprocessor definition, enabling different behavior for path tracing. (`features/Raytracing/Shaders/Raytracing/ConvertTexturesCS.hlsl`) [[1]](diffhunk://#diff-c1243dc83470e98eb36f95edf2dc4faea501becfbad3547f435c7fd103f266c7L30-R30) [[2]](diffhunk://#diff-c1243dc83470e98eb36f95edf2dc4faea501becfbad3547f435c7fd103f266c7L40-R40)

**Code Cleanup**

* Removed the check for `settings.PathTracing` before calling `ConvertTextures()` in `DrawRTGI()`, since shader selection is now handled inside `ConvertTextures()`. (`src/Features/Raytracing.cpp`)